### PR TITLE
LM-1483 Updated docker images to swisschain/dotnet-2.2 with the Let's…

### DIFF
--- a/src/Lykke.Service.EthereumApi/Dockerfile
+++ b/src/Lykke.Service.EthereumApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1.0-aspnetcore-runtime
+FROM swisschains/dotnet:2.2-aspnetcore-runtime
 WORKDIR /app
 COPY . .
 ENTRYPOINT ["dotnet", "Lykke.Service.EthereumApi.dll"]

--- a/src/Lykke.Service.EthereumSignApi/Dockerfile
+++ b/src/Lykke.Service.EthereumSignApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1.0-aspnetcore-runtime
+FROM swisschains/dotnet:2.2-aspnetcore-runtime
 WORKDIR /app
 COPY . .
 ENTRYPOINT ["dotnet", "Lykke.Service.EthereumSignApi.dll"]

--- a/src/Lykke.Service.EthereumWorker/Dockerfile
+++ b/src/Lykke.Service.EthereumWorker/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1.0-aspnetcore-runtime
+FROM swisschains/dotnet:2.2-aspnetcore-runtime
 WORKDIR /app
 COPY . .
 ENTRYPOINT ["dotnet", "Lykke.Service.EthereumWorker.dll"]


### PR DESCRIPTION
… Encrypt certificate issue fix because microsoft/dotnet:2.1.0-aspnetcore-runtime is no longer available